### PR TITLE
Journalist can add an image

### DIFF
--- a/cypress/integration/journalistCanCreateArticles.feature.js
+++ b/cypress/integration/journalistCanCreateArticles.feature.js
@@ -24,14 +24,13 @@ describe('Journalist can create articles', () => {
   });
 
   it('successfully', () => {
-    const title = 'Covid vaccine is found';
     cy.get("[data-cy='login-form']").within(() => {
       cy.get("[data-cy='email']").type('journalist@mail.com');
       cy.get("[data-cy='password']").type('password');
       cy.get("[data-cy='submit-btn']").contains('Submit').click();
     });
     cy.get('[data-cy="create-article-form"]').within(() => {
-      cy.get('[data-cy="input-title"]').type(title);
+      cy.get('[data-cy="input-title"]').type('Covid vaccine is found');
       cy.get('[data-cy="input-sub-title"]').type(
         'Each person should receive two doses of vaccine'
       );
@@ -52,7 +51,7 @@ describe('Journalist can create articles', () => {
       cy.route({
         method: 'POST',
         url: 'http://localhost:3000/api/articles',
-        response: { message: 'Something went wrong!' },
+        response: { message: 'Please fill in all input fields!' },
         status: 422,
       });
       cy.get("[data-cy='login-form']").within(() => {
@@ -71,7 +70,7 @@ describe('Journalist can create articles', () => {
       cy.get('[data-cy="create-article-button"]').click();
       cy.get('[data-cy="response-message"]').should(
         'contain',
-        'Something went wrong!'
+        'Please fill in all input fields!'
       );
     });
     it('when there is no content', () => {
@@ -82,7 +81,7 @@ describe('Journalist can create articles', () => {
       cy.get('[data-cy="create-article-button"]').click();
       cy.get('[data-cy="response-message"]').should(
         'contain',
-        'Something went wrong!'
+        'Please fill in all input fields!'
       );
     });
   });

--- a/cypress/integration/journalistCanCreateArticles.feature.js
+++ b/cypress/integration/journalistCanCreateArticles.feature.js
@@ -1,96 +1,98 @@
 /* eslint-disable no-undef */
-describe("Journalist can create articles", () => {
+describe('Journalist can create articles', () => {
   beforeEach(() => {
     cy.server();
     cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/auth/sign_in",
-      response: "fixture:journalist_can_login.json",
+      method: 'POST',
+      url: 'http://localhost:3000/api/auth/sign_in',
+      response: 'fixture:journalist_can_login.json',
       headers: {
-        uid: "journalist@mail.com",
+        uid: 'journalist@mail.com',
       },
     });
     cy.route({
-      method: "GET",
-      url: "http://localhost:3000/api/auth/validate_token**",
-      response: "fixture:journalist_can_login.json",
+      method: 'GET',
+      url: 'http://localhost:3000/api/auth/validate_token**',
+      response: 'fixture:journalist_can_login.json',
     });
     cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles",
-      response: { message: "Your article was successfully created!" },
+      method: 'POST',
+      url: 'http://localhost:3000/api/articles',
+      response: { message: 'Your article was successfully created!' },
     });
-    cy.visit("/");
+    cy.visit('/');
   });
 
-  it("successfully", () => {
+  it('successfully', () => {
+    const title = 'Covid vaccine is found';
     cy.get("[data-cy='login-form']").within(() => {
-      cy.get("[data-cy='email']").type("journalist@mail.com");
-      cy.get("[data-cy='password']").type("password");
-      cy.get("[data-cy='submit-btn']").contains("Submit").click();
+      cy.get("[data-cy='email']").type('journalist@mail.com');
+      cy.get("[data-cy='password']").type('password');
+      cy.get("[data-cy='submit-btn']").contains('Submit').click();
     });
     cy.get('[data-cy="create-article-form"]').within(() => {
-      cy.get('[data-cy="input-title"]').type("Covid vaccine is found");
+      cy.get('[data-cy="input-title"]').type(title);
       cy.get('[data-cy="input-sub-title"]').type(
-        "Each person should receive two doses of vaccine"
+        'Each person should receive two doses of vaccine'
       );
       cy.get('[data-cy="input-content"]').type(
-        "Russia has distributed vaccines months ago"
+        'Russia has distributed vaccines months ago'
       );
+      cy.get('[data-cy="file-input"]').attachFile('image.png');
       cy.get('[data-cy="create-article-button"]').click();
     });
     cy.get('[data-cy="response-message"]').should(
-      "contain",
-      "Your article was successfully created!"
+      'contain',
+      'Your article was successfully created!'
     );
   });
 
-  describe("unsuccessfully when input field is not filled in", () => {
+  describe('unsuccessfully when input field is not filled in', () => {
     beforeEach(() => {
       cy.route({
-        method: "POST",
-        url: "http://localhost:3000/api/articles",
-        response: { message: "Something went wrong!" },
+        method: 'POST',
+        url: 'http://localhost:3000/api/articles',
+        response: { message: 'Something went wrong!' },
         status: 422,
       });
       cy.get("[data-cy='login-form']").within(() => {
-        cy.get("[data-cy='email']").type("journalist@mail.com");
-        cy.get("[data-cy='password']").type("password");
-        cy.get("[data-cy='submit-btn']").contains("Submit").click();
+        cy.get("[data-cy='email']").type('journalist@mail.com');
+        cy.get("[data-cy='password']").type('password');
+        cy.get("[data-cy='submit-btn']").contains('Submit').click();
       });
     });
-    it("when there is no title", () => {
+    it('when there is no title', () => {
       cy.get('[data-cy="input-sub-title"]').type(
-        "Each person should receive two doses of vaccine"
+        'Each person should receive two doses of vaccine'
       );
       cy.get('[data-cy="input-content"]').type(
-        "Russia has distributed vaccines months ago"
+        'Russia has distributed vaccines months ago'
       );
       cy.get('[data-cy="create-article-button"]').click();
       cy.get('[data-cy="response-message"]').should(
-        "contain",
-        "Something went wrong!"
+        'contain',
+        'Something went wrong!'
       );
     });
-    it("when there is no content", () => {
-      cy.get('[data-cy="input-title"]').type("Covid vaccine is found");
+    it('when there is no content', () => {
+      cy.get('[data-cy="input-title"]').type('Covid vaccine is found');
       cy.get('[data-cy="input-sub-title"]').type(
-        "Each person should receive two doses of vaccine"
+        'Each person should receive two doses of vaccine'
       );
       cy.get('[data-cy="create-article-button"]').click();
       cy.get('[data-cy="response-message"]').should(
-        "contain",
-        "Something went wrong!"
+        'contain',
+        'Something went wrong!'
       );
     });
   });
 
-  describe("unsuccessfully when an unauthorized user tries to create an article", () => {
+  describe('unsuccessfully when an unauthorized user tries to create an article', () => {
     beforeEach(() => {
-      cy.visit("/");
+      cy.visit('/');
     });
-    it("should not display create article form", () => {
-      cy.get('[data-cy="create-article-form"]').should("not.be.visible");
+    it('should not display create article form', () => {
+      cy.get('[data-cy="create-article-form"]').should('not.be.visible');
     });
   });
 });

--- a/cypress/integration/journalistCanCreateArticles.feature.js
+++ b/cypress/integration/journalistCanCreateArticles.feature.js
@@ -38,7 +38,7 @@ describe('Journalist can create articles', () => {
       cy.get('[data-cy="input-content"]').type(
         'Russia has distributed vaccines months ago'
       );
-      cy.get('[data-cy="file-input"]').attachFile('image.png');
+      cy.get('[name="file_input"]').attachFile('image.png');
       cy.get('[data-cy="create-article-button"]').click();
     });
     cy.get('[data-cy="response-message"]').should(

--- a/cypress/integration/journalistCanLogin.feature.js
+++ b/cypress/integration/journalistCanLogin.feature.js
@@ -30,7 +30,7 @@ describe("Journalist can login", () => {
     );
   });
 
-  it("sad path: unsuccessfully with wrong credentials", () => {
+  it("unsuccessfully with wrong credentials", () => {
     cy.route({
       method: "POST",
       url: "http://localhost:3000/api/auth/sign_in",
@@ -52,7 +52,7 @@ describe("Journalist can login", () => {
     cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
   });
 
-  it("sad path: unsuccessfully with right credentials but not an journalist", () => {
+  it("unsuccessfully with only user credentials", () => {
     cy.route({
       method: "POST",
       url: "http://localhost:3000/api/auth/sign_in",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,5 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+import 'cypress-file-upload';

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "cypress": "4.1.0",
+    "cypress-file-upload": "^4.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "start-server-and-test": "^1.11.6"

--- a/src/components/CreateArticleForm.jsx
+++ b/src/components/CreateArticleForm.jsx
@@ -20,7 +20,6 @@ const CreateArticleForm = () => {
           name="title"
           placeholder="Title"
         />
-        <br />
         <Form.Field
           data-cy="input-sub-title"
           label="Subtitle"
@@ -28,21 +27,18 @@ const CreateArticleForm = () => {
           name="input_sub_title"
           placeholder="Sub Title"
         />
-        <br />
         <Form.Field
           data-cy="input-content"
           control={TextArea}
           name="input_content"
           placeholder="Content"
         />
-        <br />
         <Form.Input
           data-cy="file-input"
           name="file_input"
           placeholder="Image"
           type="file"
         />
-        <br />
         <Button
           color="green"
           data-cy="create-article-button"

--- a/src/components/CreateArticleForm.jsx
+++ b/src/components/CreateArticleForm.jsx
@@ -1,11 +1,25 @@
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { CreateArticle } from '../modules/CreateArticle';
-import { Form, Input, TextArea, Button, Message } from 'semantic-ui-react';
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { CreateArticle } from "../modules/CreateArticle";
+import {
+  Form,
+  Input,
+  TextArea,
+  Button,
+  Message,
+  Image,
+  Container,
+  Divider,
+} from "semantic-ui-react";
 
 const CreateArticleForm = () => {
   const dispatch = useDispatch();
+  const [image, setImage] = useState();
   const { createArticleMessage, errorMessage } = useSelector((state) => state);
+
+  const setImagePreview = (e) => {
+    setImage(e.target.files[0]);
+  };
 
   return (
     <>
@@ -38,6 +52,7 @@ const CreateArticleForm = () => {
           name="file_input"
           placeholder="Image"
           type="file"
+          onChange={setImagePreview}
         />
         <Button
           color="green"
@@ -58,6 +73,16 @@ const CreateArticleForm = () => {
           </Message>
         )}
       </Form>
+      <Container>
+        <Divider horizontal>Image Preview:</Divider>
+        {image && (
+          <Image
+            size="small"
+            centered="true"
+            src={URL.createObjectURL(image)}
+          />
+        )}
+      </Container>
     </>
   );
 };

--- a/src/components/CreateArticleForm.jsx
+++ b/src/components/CreateArticleForm.jsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { CreateArticle } from "../modules/CreateArticle";
-import { Form, Input, TextArea, Button, Message } from "semantic-ui-react";
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { CreateArticle } from '../modules/CreateArticle';
+import { Form, Input, TextArea, Button, Message } from 'semantic-ui-react';
 
 const CreateArticleForm = () => {
   const dispatch = useDispatch();
-  const { createArticleMessage, errorMessage } = useSelector(state => state);
+  const { createArticleMessage, errorMessage } = useSelector((state) => state);
 
   return (
     <>
@@ -34,6 +34,13 @@ const CreateArticleForm = () => {
           control={TextArea}
           name="input_content"
           placeholder="Content"
+        />
+        <br />
+        <Form.Input
+          data-cy="file-input"
+          name="file-input"
+          placeholder="Image"
+          type="file"
         />
         <br />
         <Button

--- a/src/components/CreateArticleForm.jsx
+++ b/src/components/CreateArticleForm.jsx
@@ -38,7 +38,7 @@ const CreateArticleForm = () => {
         <br />
         <Form.Input
           data-cy="file-input"
-          name="file-input"
+          name="file_input"
           placeholder="Image"
           type="file"
         />

--- a/src/modules/CreateArticle.js
+++ b/src/modules/CreateArticle.js
@@ -4,16 +4,18 @@ const CreateArticle = {
   async create(e, dispatch) {
     e.preventDefault();
     let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
-    const toBase64 = (file) => new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.readAsDataURL(file)
-      reader.onload = () => resolve(reader.result)
-      reader.onerror = () => reject(error)
-    })
+
+    const toBase64 = (file) =>
+      new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error);
+      });
     try {
-      let encodedImage
+      let encodedImage;
       if (e.target.file_input.files[0]) {
-        encodedImage = await toBase64(e.target.file_input.files[0])  
+        encodedImage = await toBase64(e.target.file_input.files[0]);
       }
       let response = await axios.post(
         "/articles",
@@ -22,7 +24,7 @@ const CreateArticle = {
             title: e.target.title.value,
             sub_title: e.target.input_sub_title.value,
             content: e.target.input_content.value,
-            file: e.target.file_input.value
+            file: encodedImage,
           },
         },
         {

--- a/src/modules/CreateArticle.js
+++ b/src/modules/CreateArticle.js
@@ -24,7 +24,7 @@ const CreateArticle = {
             title: e.target.title.value,
             sub_title: e.target.input_sub_title.value,
             content: e.target.input_content.value,
-            file: encodedImage,
+            image: encodedImage,
           },
         },
         {

--- a/src/modules/CreateArticle.js
+++ b/src/modules/CreateArticle.js
@@ -12,6 +12,7 @@ const CreateArticle = {
             title: e.target.title.value,
             sub_title: e.target.input_sub_title.value,
             content: e.target.input_content.value,
+            file: e.target.file_input.value
           },
         },
         {

--- a/src/modules/CreateArticle.js
+++ b/src/modules/CreateArticle.js
@@ -1,17 +1,11 @@
 import axios from "axios";
+import toBase64 from "./toBase64"
 
 const CreateArticle = {
   async create(e, dispatch) {
     e.preventDefault();
     let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
 
-    const toBase64 = (file) =>
-      new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = () => reject(reader.error);
-      });
     try {
       let encodedImage;
       if (e.target.file_input.files[0]) {

--- a/src/modules/CreateArticle.js
+++ b/src/modules/CreateArticle.js
@@ -4,7 +4,17 @@ const CreateArticle = {
   async create(e, dispatch) {
     e.preventDefault();
     let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
+    const toBase64 = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.onload = () => resolve(reader.result)
+      reader.onerror = () => reject(error)
+    })
     try {
+      let encodedImage
+      if (e.target.file_input.files[0]) {
+        encodedImage = await toBase64(e.target.file_input.files[0])  
+      }
       let response = await axios.post(
         "/articles",
         {

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -27,7 +27,6 @@ const performAuthentication = async (e, dispatch) => {
     }
   } 
   catch (error) {
-    console.log(error);
     dispatch({
       type: "SET_ERROR_MESSAGE",
       payload: error.response.data.errors[0],

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -25,8 +25,7 @@ const performAuthentication = async (e, dispatch) => {
       });
       localStorage.removeItem("J-tockAuth-Storage");
     }
-  } 
-  catch (error) {
+  } catch (error) {
     dispatch({
       type: "SET_ERROR_MESSAGE",
       payload: error.response.data.errors[0],

--- a/src/modules/toBase64.js
+++ b/src/modules/toBase64.js
@@ -1,10 +1,9 @@
-const toBase64 = (file) => {
+const toBase64 = (file) => 
   new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.readAsDataURL(file);
     reader.onload = () => resolve(reader.result);
     reader.onerror = () => reject(reader.error);
   });
-};
 
 export default toBase64;

--- a/src/modules/toBase64.js
+++ b/src/modules/toBase64.js
@@ -1,0 +1,10 @@
+const toBase64 = (file) => {
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+  });
+};
+
+export default toBase64;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4062,6 +4062,13 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-file-upload@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-4.1.1.tgz#952713c8104ab7008de99c65bd63f74b244fe4df"
+  integrity sha512-tX6UhuJ63rNgjdzxglpX+ZYf/bM6PDhFMtt1qCBljLtAgdearqyfD1AHqyh59rOHCjfM+bf6FA3o9b/mdaX6pw==
+  dependencies:
+    mime "^2.4.4"
+
 cypress@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.1.0.tgz#295f115d2e8a08fff2760ab49d94d876f5877aee"


### PR DESCRIPTION
(https://www.pivotaltracker.com/story/show/176031723)
### User Story
```
As a journalist
In order to make my articles more visually appealing
I would like to be able to upload and display images to my articles

```
## Changes proposed in this pull request:

* Writes a test for attaching an image
* Adds an image to fixture file
* Adds form input for attaching an image
* Adds functionality to send binary image data to API

## What I have learned working on this feature:

* Writes test for attaching an image
* Functionality to send binary image data to API

## Packages/Gems added

* cypress-file-upload

## Screenshots (Client)

<img width="1280" alt="Screen Shot 2021-01-09 at 2 29 23 PM" src="https://user-images.githubusercontent.com/62254746/104092878-1d442580-5287-11eb-811c-ef6c99b7ee90.png">
